### PR TITLE
Improved result value serialization.

### DIFF
--- a/ChanceDynamicValue.js
+++ b/ChanceDynamicValue.js
@@ -2492,11 +2492,22 @@ BlueImpMD5.prototype.md5 = function (string, key, raw) {
             if (this.chanceType) {
                 var chance = new Chance();
                 var type = this.chanceType;
+                var value = null;
+
+                // compute value
                 if (this.chanceArgs) {
                     eval('var args =' + this.chanceArgs);
-                    return chance[type].call(chance, args);
+                    value = chance[type].call(chance, args);
                 } else {
-                    return chance[type]();
+                    value = chance[type]();
+                }
+
+                // serialize value if needed
+                if (typeof value === 'object') {
+                    return JSON.stringify(value);
+                }
+                else {
+                    return value.toString();
                 }
             }
             return "Try something like `sentence` in Type";


### PR DESCRIPTION
What do you think about it? This way, instead of returning `[object Object]` when a value is an object, it serializes it as JSON, so at least the user can see what's going on.

![image](https://cloud.githubusercontent.com/assets/1319906/8318568/0502e4c6-1a06-11e5-99bf-e23147157c4f.png)
